### PR TITLE
Add hack for composite image construction

### DIFF
--- a/src/main/java/mpicbg/stitching/fusion/Fusion.java
+++ b/src/main/java/mpicbg/stitching/fusion/Fusion.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import stitching.utils.CompositeImageFixer;
 import mpicbg.imglib.container.array.ArrayContainerFactory;
 import mpicbg.imglib.container.imageplus.ImagePlusContainer;
 import mpicbg.imglib.container.imageplus.ImagePlusContainerFactory;
@@ -246,7 +247,7 @@ public class Fusion
 		{
 			result.setDimensions( size[ 2 ], numChannels, numTimePoints );
 			result = OverlayFusion.switchZCinXYCZT( result );
-			return new CompositeImage( result, CompositeImage.COMPOSITE );
+			return CompositeImageFixer.makeComposite( result, CompositeImage.COMPOSITE );
 		}
 		else
 		{
@@ -256,7 +257,7 @@ public class Fusion
 			result.setDimensions( numChannels, 1, numTimePoints );
 			
 			if ( numChannels > 1 || numTimePoints > 1 )
-				return new CompositeImage( result, CompositeImage.COMPOSITE );
+				return CompositeImageFixer.makeComposite( result, CompositeImage.COMPOSITE );
 			else
 				return result;
 		}

--- a/src/main/java/mpicbg/stitching/fusion/OverlayFusion.java
+++ b/src/main/java/mpicbg/stitching/fusion/OverlayFusion.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import stitching.utils.CompositeImageFixer;
 import mpicbg.imglib.container.imageplus.ImagePlusContainer;
 import mpicbg.imglib.container.imageplus.ImagePlusContainerFactory;
 import mpicbg.imglib.cursor.LocalizableCursor;
@@ -99,7 +100,7 @@ public class OverlayFusion
 		{
 			result.setDimensions( size[ 2 ], imp.getNChannels(), imp.getNFrames() );
 			result = OverlayFusion.switchZCinXYCZT( result );
-			return new CompositeImage( result, CompositeImage.COMPOSITE );
+			return CompositeImageFixer.makeComposite( result, CompositeImage.COMPOSITE );
 		}
 		else
 		{
@@ -109,7 +110,7 @@ public class OverlayFusion
 			result.setDimensions( imp.getNChannels(), 1, imp.getNFrames() );
 			
 			if ( imp.getNChannels() > 1 )
-				return new CompositeImage( result, CompositeImage.COMPOSITE );
+				return CompositeImageFixer.makeComposite( result, CompositeImage.COMPOSITE );
 			else
 				return result;
 		}
@@ -174,7 +175,7 @@ public class OverlayFusion
 			result.setDimensions( numChannels, 1, 1 );
 		}
 		
-		return new CompositeImage( result, CompositeImage.COMPOSITE );
+		return CompositeImageFixer.makeComposite( result, CompositeImage.COMPOSITE );
 	}
 		
 	/**
@@ -334,7 +335,7 @@ public class OverlayFusion
 		result.getCalibration().pixelWidth = imp.getCalibration().pixelWidth;
 		result.getCalibration().pixelHeight = imp.getCalibration().pixelHeight;
 		result.getCalibration().pixelDepth = imp.getCalibration().pixelDepth;
-		final CompositeImage composite = new CompositeImage( result );
+		final CompositeImage composite = CompositeImageFixer.makeComposite( result );
 		
 		return composite;
 	}
@@ -397,7 +398,7 @@ public class OverlayFusion
 		result.getCalibration().pixelWidth = imp.getCalibration().pixelWidth;
 		result.getCalibration().pixelHeight = imp.getCalibration().pixelHeight;
 		result.getCalibration().pixelDepth = imp.getCalibration().pixelDepth;
-		final CompositeImage composite = new CompositeImage( result );
+		final CompositeImage composite = CompositeImageFixer.makeComposite(  result );
 		
 		return composite;
 	}

--- a/src/main/java/plugin/Stitching_Pairwise.java
+++ b/src/main/java/plugin/Stitching_Pairwise.java
@@ -37,6 +37,7 @@ import mpicbg.stitching.StitchingParameters;
 import mpicbg.stitching.fusion.Fusion;
 import mpicbg.stitching.fusion.OverlayFusion;
 import stitching.CommonFunctions;
+import stitching.utils.CompositeImageFixer;
 
 
 public class Stitching_Pairwise implements PlugIn 
@@ -476,7 +477,7 @@ public class Stitching_Pairwise implements PlugIn
 				
 				// numchannels, z-slices, timepoints (but right now the order is still XYZCT)
 				result.setDimensions( timepoint0.getNChannels(), timepoint0.getNSlices(), imp1.getNFrames() );
-				return new CompositeImage( result, CompositeImage.COMPOSITE );
+				return CompositeImageFixer.makeComposite( result, CompositeImage.COMPOSITE );
 			}
 			else
 			{

--- a/src/main/java/stitching/utils/CompositeImageFixer.java
+++ b/src/main/java/stitching/utils/CompositeImageFixer.java
@@ -1,0 +1,47 @@
+package stitching.utils;
+
+import ij.CompositeImage;
+import ij.ImagePlus;
+
+/**
+ * Utility class to work around the {@link CompositeImage} nature of converting
+ * stacks to channels.
+ *
+ * @author Mark Hiner
+ */
+public final class CompositeImageFixer {
+
+	/**
+	 * see {@link #makeComposite(ImagePlus, int)}
+	 */
+	public static CompositeImage makeComposite(ImagePlus imp) {
+		return makeComposite(imp, CompositeImage.COLOR);
+	}
+
+	/**
+	 * -- HACK --
+	 * <p>
+	 * Workaround for the fact that if there are less than 7 slices in an
+	 * ImagePlus, the CompositeImage constructor will convert those slices
+	 * to channels.
+	 * </p>
+	 * <p>
+	 * This method will always construct a CompositeImage with the same
+	 * dimensions as the input ImagePlus.
+	 * </p>
+	 */
+	public static CompositeImage makeComposite(ImagePlus imp, int mode) {
+		// cache the (correct) channel, frame and slice counts
+		final int channels = imp.getNChannels();
+		final int frames = imp.getNFrames();
+		final int slices = imp.getNSlices();
+
+		// construct the composite image
+		final CompositeImage cmp = new CompositeImage(imp, mode);
+
+		// reset the correct dimension counts
+		cmp.setDimensions(channels, slices, frames);
+
+		return cmp;
+	}
+}


### PR DESCRIPTION
Created CompositeImageFixer class which ensures C,Z,T dimensions are
preserved when constructing a new CompositeImage.

Workaround for the fact that if there are less than MAX_CHANNELS slices
of a stack, all dimensions are converted to channels by the
CompositeImage constructor.
