### PR TITLE
Fusion: display fusion in real time

### DIFF
--- a/src/main/java/mpicbg/stitching/fusion/Fusion.java
+++ b/src/main/java/mpicbg/stitching/fusion/Fusion.java
@@ -47,6 +47,9 @@ import stitching.utils.CompositeImageFixer;
  */
 public class Fusion 
 {
+
+	public static boolean displayFusion = false;
+
 	/**
 	 * 
 	 * @param targetType
@@ -287,14 +290,16 @@ public class Fusion
 		final long[] lastDraw = {System.currentTimeMillis()};
 		final ImagePlus[] fusionImp = new ImagePlus[1];
 
-		try {
-			fusionImp[0] =
-				((ImagePlusContainer<?, ?>) output.getContainer()).getImagePlus();
-			fusionImp[0].setTitle("fusing...");
-			fusionImp[0].show();
-		}
-		catch (ImgLibException e) {
-			IJ.log("Output image has no ImageJ type: " + e);
+		if (displayFusion) {
+			try {
+				fusionImp[0] =
+					((ImagePlusContainer<?, ?>) output.getContainer()).getImagePlus();
+				fusionImp[0].setTitle("fusing...");
+				fusionImp[0].show();
+			}
+			catch (ImgLibException e) {
+				IJ.log("Output image has no ImageJ type: " + e);
+			}
 		}
 
 		final int[][] max = new int[ numImages ][ numDimensions ];
@@ -420,14 +425,16 @@ A:        					for ( int i = 0; i < numImages; ++i )
 		final long[] lastDraw = {System.currentTimeMillis()};
 		final ImagePlus[] fusionImp = new ImagePlus[1];
 
-		try {
-			fusionImp[0] =
-				((ImagePlusContainer<?, ?>) output.getContainer()).getImagePlus();
-			fusionImp[0].setTitle("fusing...");
-			fusionImp[0].show();
-		}
-		catch (ImgLibException e) {
-			IJ.log("Output image has no ImageJ type: " + e);
+		if (displayFusion) {
+			try {
+				fusionImp[0] =
+					((ImagePlusContainer<?, ?>) output.getContainer()).getImagePlus();
+				fusionImp[0].setTitle("fusing...");
+				fusionImp[0].show();
+			}
+			catch (ImgLibException e) {
+				IJ.log("Output image has no ImageJ type: " + e);
+			}
 		}
 		
 		

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -80,6 +80,7 @@ public class Stitching_Grid implements PlugIn
 	public static boolean defaultIgnoreZStage = false;
 	public static boolean defaultSubpixelAccuracy = true;
 	public static boolean defaultDownSample = false;
+	public static boolean defaultDisplayFusion = false;
 	public static boolean writeOnlyTileConfStatic = false;
 	
 	public static boolean defaultIgnoreCalibration = false;
@@ -194,6 +195,7 @@ public class Stitching_Grid implements PlugIn
 		gd.addCheckbox( "Ignore_Z_stage position", defaultIgnoreZStage);
 		gd.addCheckbox( "Subpixel_accuracy", defaultSubpixelAccuracy );
 		gd.addCheckbox( "Downsample_tiles", defaultDownSample);
+		gd.addCheckbox( "Display_fusion", defaultDisplayFusion);
 		gd.addCheckbox( "Use_virtual_input_images (Slow! Even slower when combined with subpixel accuracy during fusion!)", defaultVirtualInput );
 		gd.addChoice( "Computation_parameters", CommonFunctions.cpuMemSelect, CommonFunctions.cpuMemSelect[ defaultMemorySpeedChoice ] );
 		gd.addChoice( "Image_output", resultChoices, resultChoices[ defaultResult ] );
@@ -318,6 +320,7 @@ public class Stitching_Grid implements PlugIn
 
 		params.subpixelAccuracy = defaultSubpixelAccuracy = gd.getNextBoolean();
 		final boolean downSample = params.downSample = defaultDownSample = gd.getNextBoolean();
+		Fusion.displayFusion = defaultDisplayFusion = gd.getNextBoolean();
 		params.virtual = defaultVirtualInput = gd.getNextBoolean();
 		params.cpuMemChoice = defaultMemorySpeedChoice = gd.getNextChoiceIndex();
 		params.outputVariant = defaultResult = gd.getNextChoiceIndex();


### PR DESCRIPTION
When fusing blocks, an intermediate image will be displayed in real time
as the fused pixels are filled in. This should be helpful in determining
how much progress (if any) is actually being made during the fusion
process.

Only one time point/channel will be displayed at a time, and the
displayed image may not perfectly represent the final fused image - as
it will undergo rearrangement and post processing.

Note: as this does introduce operations per pixel during the fusion
process, this was benchmarked. On an 11 minute fusion, the time cost of
drawing the fusion in progress is < 20 seconds (under 3%).

Closes #8
