### PR TITLE
Multiseries stitching using coordinates from a tile configuration file.

### DIFF
--- a/src/main/java/plugin/GridType.java
+++ b/src/main/java/plugin/GridType.java
@@ -17,7 +17,17 @@ public class GridType
 	final private String paperURL = "http://bioinformatics.oxfordjournals.org/cgi/content/abstract/btp184";
 
 	// Modified by John Lapage: added the 'Sequential Images' option. 	
-	final public static String[] choose1 = new String[]{ "Grid: row-by-row", "Grid: column-by-column", "Grid: snake by rows", "Grid: snake by columns", "Filename defined position", "Unknown position", "Positions from file" , "Sequential Images" };
+    // This defines the value returned by getType() later:
+	final public static String[] choose1 = new String[]{
+        "Grid: row-by-row",           // 0
+        "Grid: column-by-column",     // 1
+        "Grid: snake by rows",        // 2
+        "Grid: snake by columns",     // 3
+        "Filename defined position",  // 4
+        "Unknown position",           // 5
+        "Positions from file",        // 6
+        "Sequential Images"           // 7
+    };
 	final public static String[][] choose2 = new String[ choose1.length ][];
 	final public static String[] allChoices;
 	
@@ -132,16 +142,24 @@ public class GridType
 	public int getType() { return type; }
 	public int getOrder() { return order; }
 	
+    // order options definitions:
 	static
 	{
+        // 0: Grid: row-by-row
 		choose2[ 0 ] = new String[]{ "Right & Down                ", "Left & Down", "Right & Up", "Left & Up" };
+        // 1: Grid: column-by-column
 		choose2[ 1 ] = new String[]{ "Down & Right                ", "Down & Left", "Up & Right", "Up & Left" };
+        // 2: Grid: snake by rows
 		choose2[ 2 ] = new String[]{ "Right & Down                ", "Left & Down", "Right & Up", "Left & Up" };
+        // 3: Grid: snake by columns
 		choose2[ 3 ] = new String[]{ "Down & Right                ", "Down & Left", "Up & Right", "Up & Left" };
+        // 4: Filename defined position
 		choose2[ 4 ] = new String[]{ "Defined by filename         " };
+        // 5: Unknown position
 		choose2[ 5 ] = new String[]{ "All files in directory" };
+        // 6: Positions from file
 		choose2[ 6 ] = new String[]{ "Defined by TileConfiguration", "Defined by image metadata" };
-		// Added by John Lapage: same option as with Unknown Positions
+        // 7: Sequential Images
 		choose2[ 7 ] = new String[]{ "All files in directory" };
 
 		// the interactive changing is not compatible with the macro language, 

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1068,8 +1068,16 @@ public class Stitching_Grid implements PlugIn
 						}
 
 					} else if ( line.startsWith( "multiseries" ) )  {
-						multiSeries = true;
-						logger(pfx + lineNo + ": parsing MultiSeries configuration.");
+						String entries[] = line.split( "=" );
+						if ( entries.length != 2 ) {
+							logger(pfx + lineNo + " does not look like [ multiseries = (true|false) ]: " + line);
+							return null;
+						}
+
+						if (entries[1].trim() == "true") {
+							multiSeries = true;
+							logger(pfx + lineNo + ": parsing MultiSeries configuration.");
+						}
 
 					} else {  // body parsing (tiles + coordinates)
 						if ( dim < 0 ) {

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1075,11 +1075,10 @@ public class Stitching_Grid implements PlugIn
 							logger(pfx + lineNo + " does not have 3 entries! [fileName; ImagePlus; (x,y,...)]");
 							return null;						
 						}
+
 						String imageName = entries[0].trim();
-						String imp = entries[1].trim();
-						
-						if (imageName.length() == 0 && imp.length() == 0) {
-							logger(pfx + lineNo + ": You have to give a filename or a ImagePlus [fileName; ImagePlus; (x,y,...)]: " + line);
+						if (imageName.length() == 0) {
+							logger(pfx + lineNo + ": You have to give a filename [fileName; ; (x,y,...)]: " + line);
 							return null;						
 						}
 						

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1093,7 +1093,7 @@ public class Stitching_Grid implements PlugIn
 						// read image tiles
 						String entries[] = line.split(";");
 						if (entries.length != 3) {
-							logger(pfx + lineNo + " does not have 3 entries! [fileName; ImagePlus; (x,y,...)]");
+							logger(pfx + lineNo + " does not have 3 entries! [fileName; seriesNr; (x,y,...)]");
 							return null;						
 						}
 

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1095,13 +1095,6 @@ public class Stitching_Grid implements PlugIn
 							return null;
 						}
 						
-						ImageCollectionElement element = new ImageCollectionElement( new File( directory, imageName ), index++ );
-						element.setDimensionality( dim );
-						
-						if ( dim == 3 )
-							element.setModel( new TranslationModel3D() );
-						else
-							element.setModel( new TranslationModel2D() );
 
 						final float[] offset = new float[ dim ];
 						for ( int i = 0; i < dim; i++ ) {
@@ -1114,6 +1107,14 @@ public class Stitching_Grid implements PlugIn
 							}
 						}
 						
+						// now we can assemble the ImageCollectionElement:
+						ImageCollectionElement element = new ImageCollectionElement(
+								new File( directory, imageName ), index++ );
+						element.setDimensionality( dim );
+						if ( dim == 3 )
+							element.setModel( new TranslationModel3D() );
+						else
+							element.setModel( new TranslationModel2D() );
 						element.setOffset( offset );
 						elements.add( element );
 					}

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1415,7 +1415,7 @@ public class Stitching_Grid implements PlugIn
 
 	protected void writeRegisteredTileConfiguration( final File file, final ArrayList< ImageCollectionElement > elements )
 	{
-    	// write the initial tileconfiguration
+		// write the tileconfiguration using the translation model
 		final PrintWriter out = TextFileAccess.openFileWrite( file );
 		final int dimensionality = elements.get( 0 ).getDimensionality();
 		

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1031,6 +1031,7 @@ public class Stitching_Grid implements PlugIn
 		final ArrayList< ImageCollectionElement > elements = new ArrayList< ImageCollectionElement >();
 		int dim = -1;
 		int index = 0;
+		boolean multiSeries = false;
 		String pfx = "Stitching_Grid.getLayoutFromFile: ";
 		try {
 			final BufferedReader in = TextFileAccess.openFileRead( new File( directory, layoutFile ) );
@@ -1082,6 +1083,12 @@ public class Stitching_Grid implements PlugIn
 							return null;						
 						}
 						
+						String imageSeries = entries[1].trim();  // sub-volume (series nr)
+						if (imageSeries.length() > 0) {
+							logger(pfx + lineNo + ": Found sub-volume (series): " + imageSeries);
+							multiSeries = true;
+						}
+
 						String point = entries[2].trim();  // coordinates
 						if (!point.startsWith("(") || !point.endsWith(")")) {
 							logger(pfx + lineNo + ": Wrong format of coordinates: (x,y,...): " + point);

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1464,6 +1464,8 @@ public class Stitching_Grid implements PlugIn
 		final PrintWriter out = TextFileAccess.openFileWrite( file );
 		final int dimensionality = elements.get( 0 ).getDimensionality();
 		
+		logger( "Writing registered TileConfiguration: " + file );
+
 		out.println( "# Define the number of dimensions we are working on" );
         out.println( "dim = " + dimensionality );
         out.println( "" );

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1032,13 +1032,9 @@ public class Stitching_Grid implements PlugIn
 		int dim = -1;
 		int index = 0;
 		String pfx = "Stitching_Grid.getLayoutFromFile: ";
-		
-		try
-		{
+		try {
 			final BufferedReader in = TextFileAccess.openFileRead( new File( directory, layoutFile ) );
-			
-			if ( in == null )
-			{
+			if ( in == null ) {
 				logger(pfx + "Cannot find tileconfiguration file '" + new File( directory, layoutFile ).getAbsolutePath() + "'");
 				return null;
 			}
@@ -1047,68 +1043,55 @@ public class Stitching_Grid implements PlugIn
 			while ( in.ready() ) {
 				String line = in.readLine().trim();
 				lineNo++;
-				if ( !line.startsWith( "#" ) && line.length() > 3 )
-				{
-					if ( line.startsWith( "dim" ) )
-					{
+				if ( !line.startsWith( "#" ) && line.length() > 3 ) {
+					if ( line.startsWith( "dim" ) ) {
 						String entries[] = line.split( "=" );
-						if ( entries.length != 2 )
-						{
+						if ( entries.length != 2 ) {
 							logger(pfx + lineNo + " does not look like [ dim = n ]: " + line);
 							return null;						
 						}
 						
-						try
-						{
+						try {
 							dim = Integer.parseInt( entries[1].trim() );
 						}
-						catch ( NumberFormatException e )
-						{
+						catch ( NumberFormatException e ) {
 							logger(pfx + lineNo + ": Cannot parse dimensionality: " + entries[1].trim());
 							return null;														
 						}
-					}
-					else
-					{
-						if ( dim < 0 )
-						{
+					} else {
+						if ( dim < 0 ) {
 							logger(pfx + lineNo + ": Header missing, should look like [dim = n], but first line is: " + line);
 							return null;							
 						}
 						
-						if ( dim < 2 || dim > 3 )
-						{
+						if ( dim < 2 || dim > 3 ) {
 							logger(pfx + lineNo + ": only dimensions of 2 and 3 are supported: " + line);
 							return null;							
 						}
 						
 						// read image tiles
 						String entries[] = line.split(";");
-						if (entries.length != 3)
-						{
+						if (entries.length != 3) {
 							logger(pfx + lineNo + " does not have 3 entries! [fileName; ImagePlus; (x,y,...)]");
 							return null;						
 						}
 						String imageName = entries[0].trim();
 						String imp = entries[1].trim();
 						
-						if (imageName.length() == 0 && imp.length() == 0)
-						{
+						if (imageName.length() == 0 && imp.length() == 0) {
 							logger(pfx + lineNo + ": You have to give a filename or a ImagePlus [fileName; ImagePlus; (x,y,...)]: " + line);
 							return null;						
 						}
 						
 						String point = entries[2].trim();
-						if (!point.startsWith("(") || !point.endsWith(")"))
-						{
+						if (!point.startsWith("(") || !point.endsWith(")")) {
 							logger(pfx + lineNo + ": Wrong format of coordinates: (x,y,...): " + point);
 							return null;
 						}
 						
 						point = point.substring(1, point.length() - 1);
 						String points[] = point.split(",");
-						if (points.length != dim)
-						{
+						if (points.length != dim) {
 							logger(pfx + lineNo + ": Wrong format of coordinates: (x,y,z,...), dim = " + dim + ": " + point);
 							return null;
 						}
@@ -1122,14 +1105,11 @@ public class Stitching_Grid implements PlugIn
 							element.setModel( new TranslationModel2D() );
 
 						final float[] offset = new float[ dim ];
-						for ( int i = 0; i < dim; i++ )
-						{
-							try
-							{
+						for ( int i = 0; i < dim; i++ ) {
+							try {
 								offset[ i ] = Float.parseFloat( points[i].trim() ); 
 							}
-							catch (NumberFormatException e)
-							{
+							catch (NumberFormatException e) {
 								logger(pfx + lineNo + ": Cannot parse number: " + points[i].trim());
 								return null;							
 							}
@@ -1141,8 +1121,7 @@ public class Stitching_Grid implements PlugIn
 				}
 			}
 		}
-		catch ( IOException e )
-		{
+		catch ( IOException e ) {
 			logger( "Stitching_Grid.getLayoutFromFile: " + e );
 			return null;
 		}

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -263,8 +263,11 @@ public class Stitching_Grid implements PlugIn
 		// "Positions from file" + "Defined by metadata"
 		{
 			seriesFile = defaultSeriesFile = gd.getNextString();
-			outputFile = null;
-			directory = null;
+			outputFile = defaultTileConfiguration;
+			// derive directory from the file (the dialog doesn't provide one)
+			directory = seriesFile.trim();
+			directory = directory.replace('\\', '/');
+			directory = directory.split("/[^/]*$")[0];  // remove the file part
 			filenames = null;
 			confirmFiles = false;
 		}
@@ -515,6 +518,7 @@ public class Stitching_Grid implements PlugIn
 			IJ.log( imt.getImagePlus().getTitle() + ": " + imt.getModel() );
 		
     	// write the file tileconfiguration
+        // NOTE: outputFile should never be null anyway!
 		if ( params.computeOverlap && outputFile != null )
 		{
 			if ( outputFile.endsWith( ".txt" ) )

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1031,6 +1031,7 @@ public class Stitching_Grid implements PlugIn
 		final ArrayList< ImageCollectionElement > elements = new ArrayList< ImageCollectionElement >();
 		int dim = -1;
 		int index = 0;
+		String pfx = "Stitching_Grid.getLayoutFromFile: ";
 		
 		try
 		{
@@ -1038,10 +1039,11 @@ public class Stitching_Grid implements PlugIn
 			
 			if ( in == null )
 			{
-				IJ.log( "Cannot find tileconfiguration file '" + new File( directory, layoutFile ).getAbsolutePath() + "'" );
+				logger(pfx + "Cannot find tileconfiguration file '" + new File( directory, layoutFile ).getAbsolutePath() + "'");
 				return null;
 			}
 			int lineNo = 0;
+			pfx += "Line ";
 			while ( in.ready() ) {
 				String line = in.readLine().trim();
 				lineNo++;
@@ -1052,8 +1054,7 @@ public class Stitching_Grid implements PlugIn
 						String entries[] = line.split( "=" );
 						if ( entries.length != 2 )
 						{
-							System.out.println( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + " does not look like [ dim = n ]: " + line);
-							IJ.log( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + " does not look like [ dim = n ]: " + line);
+							logger(pfx + lineNo + " does not look like [ dim = n ]: " + line);
 							return null;						
 						}
 						
@@ -1063,8 +1064,7 @@ public class Stitching_Grid implements PlugIn
 						}
 						catch ( NumberFormatException e )
 						{
-							System.out.println( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Cannot parse dimensionality: " + entries[1].trim());
-							IJ.log( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Cannot parse dimensionality: " + entries[1].trim());
+							logger(pfx + lineNo + ": Cannot parse dimensionality: " + entries[1].trim());
 							return null;														
 						}
 					}
@@ -1072,15 +1072,13 @@ public class Stitching_Grid implements PlugIn
 					{
 						if ( dim < 0 )
 						{
-							System.out.println( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Header missing, should look like [dim = n], but first line is: " + line);
-							IJ.log( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Header missing, should look like [dim = n], but first line is: " + line);
+							logger(pfx + lineNo + ": Header missing, should look like [dim = n], but first line is: " + line);
 							return null;							
 						}
 						
 						if ( dim < 2 || dim > 3 )
 						{
-							System.out.println( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": only dimensions of 2 and 3 are supported: " + line);
-							IJ.log( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": only dimensions of 2 and 3 are supported: " + line);
+							logger(pfx + lineNo + ": only dimensions of 2 and 3 are supported: " + line);
 							return null;							
 						}
 						
@@ -1088,8 +1086,7 @@ public class Stitching_Grid implements PlugIn
 						String entries[] = line.split(";");
 						if (entries.length != 3)
 						{
-							System.out.println( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + " does not have 3 entries! [fileName; ImagePlus; (x,y,...)]");
-							IJ.log( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + " does not have 3 entries! [fileName; ImagePlus; (x,y,...)]");
+							logger(pfx + lineNo + " does not have 3 entries! [fileName; ImagePlus; (x,y,...)]");
 							return null;						
 						}
 						String imageName = entries[0].trim();
@@ -1097,16 +1094,14 @@ public class Stitching_Grid implements PlugIn
 						
 						if (imageName.length() == 0 && imp.length() == 0)
 						{
-							System.out.println( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": You have to give a filename or a ImagePlus [fileName; ImagePlus; (x,y,...)]: " + line);
-							IJ.log( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": You have to give a filename or a ImagePlus [fileName; ImagePlus; (x,y,...)]: " + line);
+							logger(pfx + lineNo + ": You have to give a filename or a ImagePlus [fileName; ImagePlus; (x,y,...)]: " + line);
 							return null;						
 						}
 						
 						String point = entries[2].trim();
 						if (!point.startsWith("(") || !point.endsWith(")"))
 						{
-							System.out.println( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Wrong format of coordinates: (x,y,...): " + point);
-							IJ.log( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Wrong format of coordinates: (x,y,...): " + point);
+							logger(pfx + lineNo + ": Wrong format of coordinates: (x,y,...): " + point);
 							return null;
 						}
 						
@@ -1114,8 +1109,7 @@ public class Stitching_Grid implements PlugIn
 						String points[] = point.split(",");
 						if (points.length != dim)
 						{
-							System.out.println( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Wrong format of coordinates: (x,y,z,..), dim = " + dim + ": " + point);
-							IJ.log( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Wrong format of coordinates: (x,y,z,...), dim = " + dim + ": " + point);
+							logger(pfx + lineNo + ": Wrong format of coordinates: (x,y,z,...), dim = " + dim + ": " + point);
 							return null;
 						}
 						
@@ -1136,8 +1130,7 @@ public class Stitching_Grid implements PlugIn
 							}
 							catch (NumberFormatException e)
 							{
-								System.out.println( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Cannot parse number: " + points[i].trim());
-								IJ.log( "Stitching_Grid.getLayoutFromFile: Line " + lineNo + ": Cannot parse number: " + points[i].trim());
+								logger(pfx + lineNo + ": Cannot parse number: " + points[i].trim());
 								return null;							
 							}
 						}
@@ -1150,8 +1143,7 @@ public class Stitching_Grid implements PlugIn
 		}
 		catch ( IOException e )
 		{
-			System.out.println( "Stitch_Grid.getLayoutFromFile: " + e );
-			IJ.log( "Stitching_Grid.getLayoutFromFile: " + e );
+			logger( "Stitching_Grid.getLayoutFromFile: " + e );
 			return null;
 		}
 		

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1044,7 +1044,7 @@ public class Stitching_Grid implements PlugIn
 				String line = in.readLine().trim();
 				lineNo++;
 				if ( !line.startsWith( "#" ) && line.length() > 3 ) {
-					if ( line.startsWith( "dim" ) ) {
+					if ( line.startsWith( "dim" ) ) {  // dimensionality parsing
 						String entries[] = line.split( "=" );
 						if ( entries.length != 2 ) {
 							logger(pfx + lineNo + " does not look like [ dim = n ]: " + line);
@@ -1058,7 +1058,7 @@ public class Stitching_Grid implements PlugIn
 							logger(pfx + lineNo + ": Cannot parse dimensionality: " + entries[1].trim());
 							return null;														
 						}
-					} else {
+					} else {  // body parsing (tiles + coordinates)
 						if ( dim < 0 ) {
 							logger(pfx + lineNo + ": Header missing, should look like [dim = n], but first line is: " + line);
 							return null;							
@@ -1083,13 +1083,13 @@ public class Stitching_Grid implements PlugIn
 							return null;						
 						}
 						
-						String point = entries[2].trim();
+						String point = entries[2].trim();  // coordinates
 						if (!point.startsWith("(") || !point.endsWith(")")) {
 							logger(pfx + lineNo + ": Wrong format of coordinates: (x,y,...): " + point);
 							return null;
 						}
 						
-						point = point.substring(1, point.length() - 1);
+						point = point.substring(1, point.length() - 1);  // crop enclosing braces
 						String points[] = point.split(",");
 						if (points.length != dim) {
 							logger(pfx + lineNo + ": Wrong format of coordinates: (x,y,z,...), dim = " + dim + ": " + point);

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -634,6 +634,12 @@ public class Stitching_Grid implements PlugIn
     		element.close();
 	}
 
+	void logger (final String message)
+	{
+		System.out.println(message);
+		IJ.log(message);
+	}
+
 	/**
 	 * Generates a ROI for each tile in the list of optimized images. The
 	 * fusedImage is the resultant on which the ROIs will be drawn. The offset

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -790,6 +790,42 @@ public class Stitching_Grid implements PlugIn
 
 		return in;
 	}
+	
+	protected ImagePlus[] openBF( String multiSeriesFileName, boolean splitC,
+			boolean splitT, boolean splitZ, boolean autoScale, boolean crop,
+			boolean allSeries )
+	{
+		ImporterOptions options;
+		ImagePlus[] imps = null;
+		try
+		{
+			options = new ImporterOptions();
+			options.setId( new File( multiSeriesFileName ).getAbsolutePath() );
+			options.setSplitChannels( splitC );
+			options.setSplitTimepoints( splitT );
+			options.setSplitFocalPlanes( splitZ );
+			options.setAutoscale( autoScale );
+			options.setStackFormat(ImporterOptions.VIEW_HYPERSTACK);
+			options.setStackOrder(ImporterOptions.ORDER_XYCZT);
+			options.setCrop( crop );
+			
+			options.setOpenAllSeries( allSeries );
+			
+			imps = BF.openImagePlus( options );
+		}
+		catch (Exception e)
+		{
+			IJ.log( "Cannot open multiseries file: " + e );
+			e.printStackTrace();
+			return null;
+		}
+		return imps;
+	}
+	
+	protected ImagePlus[] openBFDefault( String multiSeriesFileName )
+	{
+		return openBF(multiSeriesFileName, false, false, false, false, false, true);
+	}
 
 	protected ArrayList< ImageCollectionElement > getLayoutFromMultiSeriesFile( final String multiSeriesFile, final double increaseOverlap, final boolean ignoreCalibration, final boolean invertX, final boolean invertY, final boolean ignoreZStage, final Downsampler ds )
 	{

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1074,7 +1074,7 @@ public class Stitching_Grid implements PlugIn
 							return null;
 						}
 
-						if (entries[1].trim() == "true") {
+						if (entries[1].trim().equals("true")) {
 							multiSeries = true;
 							logger(pfx + lineNo + ": parsing MultiSeries configuration.");
 						}

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -260,6 +260,7 @@ public class Stitching_Grid implements PlugIn
 		final String filenames;
 		
 		if ( gridType == 6 && gridOrder == 1 )
+		// "Positions from file" + "Defined by metadata"
 		{
 			seriesFile = defaultSeriesFile = gd.getNextString();
 			outputFile = null;
@@ -385,9 +386,10 @@ public class Stitching_Grid implements PlugIn
 		//John Lapage modified this: copying setup for Unknown Positions
 		else if ( gridType == 5 || gridType == 7)
 			elements = getAllFilesInDirectory( directory, confirmFiles );
-		else if ( gridType == 6 && gridOrder == 1 )
-			elements = getLayoutFromMultiSeriesFile( seriesFile, increaseOverlap, ignoreCalibration, invertX, invertY, ignoreZStage, ds );
-		else if ( gridType == 6 )
+		else if ( gridType == 6 && gridOrder == 1 )  // positions from file metadata
+			elements = getLayoutFromMultiSeriesFile( seriesFile, increaseOverlap,
+				ignoreCalibration, invertX, invertY, ignoreZStage, ds );
+		else if ( gridType == 6 )  // positions from tile configuration file
 			elements = getLayoutFromFile( directory, outputFile, ds );
 		else
 			elements = null;
@@ -957,7 +959,7 @@ public class Stitching_Grid implements PlugIn
 			for ( int series = 0; series < elements.size(); ++series )
 			{
 				final ImageCollectionElement element = elements.get( series );
-				element.setImagePlus( imps[ series ] );
+				element.setImagePlus( imps[ series ] );  // assign the sub-series to the elements list
 				
 				if ( element.getDimensionality() == 2 )
 					IJ.log( "series " + series + ": position = (" + element.getOffset( 0 ) + "," + element.getOffset( 1 ) + ") [px], " +
@@ -993,11 +995,8 @@ public class Stitching_Grid implements PlugIn
 				IJ.log( "Cannot find tileconfiguration file '" + new File( directory, layoutFile ).getAbsolutePath() + "'" );
 				return null;
 			}
-			
 			int lineNo = 0;
-			
-			while ( in.ready() )
-			{
+			while ( in.ready() ) {
 				String line = in.readLine().trim();
 				lineNo++;
 				if ( !line.startsWith( "#" ) && line.length() > 3 )
@@ -1076,7 +1075,7 @@ public class Stitching_Grid implements PlugIn
 						
 						ImageCollectionElement element = new ImageCollectionElement( new File( directory, imageName ), index++ );
 						element.setDimensionality( dim );
-								
+						
 						if ( dim == 3 )
 							element.setModel( new TranslationModel3D() );
 						else

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -1032,10 +1032,10 @@ public class Stitching_Grid implements PlugIn
 		int dim = -1;
 		int index = 0;
 		boolean multiSeries = false;
-		// A HashMap using the filename as the key is used to access the
-		// individual tiles of a multiSeriesFile. This way it's very easy to
-		// check if a file has already been opened. Note that the map doesn't
-		// get used in the case of single series files below!
+		// A HashMap using the filename (including the full path) as the key is
+		// used to access the individual tiles of a multiSeriesFile. This way
+		// it's very easy to check if a file has already been opened. Note that
+		// the map doesn't get used in the case of single series files below!
 		// TODO: check performance on large datasets! Use an array for the
 		// ImagePlus'es otherwise and store the index number in the hash map!
 		Map<String, ImagePlus[]> multiSeriesMap = new HashMap<String, ImagePlus[]>();
@@ -1154,11 +1154,12 @@ public class Stitching_Grid implements PlugIn
 						element.setOffset( offset );
 
 						if (multiSeries) {
-							if (multiSeriesMap.get(imageName) == null) {
-								logger(pfx + lineNo + ": Loading MultiSeries file: " + element.getFile().getAbsolutePath());
-								multiSeriesMap.put(imageName, openBFDefault(element.getFile().getAbsolutePath()));
+							final String imageNameFull = element.getFile().getAbsolutePath();
+							if (multiSeriesMap.get(imageNameFull) == null) {
+								logger(pfx + lineNo + ": Loading MultiSeries file: " + imageNameFull);
+								multiSeriesMap.put(imageNameFull, openBFDefault(imageNameFull));
 							}
-							element.setImagePlus(multiSeriesMap.get(imageName)[seriesNr]);
+							element.setImagePlus(multiSeriesMap.get(imageNameFull)[seriesNr]);
 						}
 
 						elements.add( element );


### PR DESCRIPTION
This PR adds the possibility to stitch multi-series files (`.lsm`, `.czi`, `.lif`, ...) using coordinates from a `TileConfiguration.txt` file.

I've created this upon the [reply](https://list.nih.gov/cgi-bin/wa.exe?A2=ind1412&L=IMAGEJ&F=&S=&P=173642) by @ctrueden on the ImageJ mailing list. As explained in my email to the list, we need this as we're having a user that acquired a lot of datasets where each channel was saved in a separate `.lsm` file, where only one of the channels is leading to good results when running the stitcher. So we wanted to re-use the results calculated by the stitcher for this channel on the other channels, but the current code did not allow for specifying coordinates for a multi-series file.

A couple of remarks:
* A new *optional* keyword `multiseries` is introduced for the syntax of the `TileConfiguration.txt`.
* As I couldn't find any reference to the *second* field of the tile specification syntax, I used this one to specify the series index number of the multi-series file. Let me know if you prefer another approach, I'm happy to change the code accordingly.
* It took me a while to dig through the existing code and understand it, therefore I've added some comments that might be useful for other people looking at the code later as well. Furthermore, I felt the strong need to compact the code a little bit for being able to *see* more of it on my screen at one time. That's why I slightly changed the coding style of the adjusted method (e.g. placed curly brackets on the same line as an `if` statement). If you don't like this I can revert them, but to me this was a great help!
* For the same reason I've added convenience methods like `logger()`, `openBF()` and `openBFDefault()` to reduce code duplication. Although I'm quite sure @ctrueden has probably a good recommendation of how to do the logging in a much nicer way...?
* The stitcher is now also writing a `TileConfiguration.registered.txt` in case of using coordinates from the metadata, so the configuration created there can easily be adjusted and used for using it with the new functionality.

I have reassembled my commits and tried to group them somehow logically, hoping they are easy to understand this way. I'd be more than happy to see this merged back into master, so feel free to give me your feedback!

Some manual testing was done to cover three cases: stitching using coordinates from the metadata, stitching using individual files using a tile configuration and (of course) the new feature, stitching a single multi-series file using a tile configuration file.