### PR TITLE
Fix series assignment for multiseries files

### DIFF
--- a/src/main/java/mpicbg/stitching/ImageCollectionElement.java
+++ b/src/main/java/mpicbg/stitching/ImageCollectionElement.java
@@ -109,6 +109,7 @@ public class ImageCollectionElement
 			
 			ImporterOptions options = new ImporterOptions();
 			options.setId( file.getAbsolutePath() );
+			options.setSeriesOn(getIndex(), true);
 			options.setSplitChannels( false );
 			options.setSplitTimepoints( false );
 			options.setSplitFocalPlanes( false );

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -892,7 +892,7 @@ public class Stitching_Grid implements PlugIn
 			// CTR HACK: In the case of a single series, we treat each time point
 			// as a separate series for the purpose of stitching tiles.
 			timeHack = numSeries == 1;
-
+			
 			for ( int series = 0; series < numSeries; ++series )
 			{
 				Log.debug( "fetching data for series:  " + series );
@@ -963,7 +963,7 @@ public class Stitching_Grid implements PlugIn
 					}
 					else
 					{
-						element = new ImageCollectionElement( new File( multiSeriesFile ), elements.size() );
+						element = new ImageCollectionElement( new File( multiSeriesFile ), series );
 						element.setModel( new TranslationModel3D() );
 						element.setOffset( new float[]{ (float)locationX, (float)locationY, (float)locationZ } );
 						element.setDimensionality( 3 );

--- a/src/main/java/plugin/Stitching_Grid.java
+++ b/src/main/java/plugin/Stitching_Grid.java
@@ -956,7 +956,7 @@ public class Stitching_Grid implements PlugIn
 
 					if ( dim == 2 )
 					{
-						element = new ImageCollectionElement( new File( multiSeriesFile ), elements.size() );
+						element = new ImageCollectionElement( new File( multiSeriesFile ), series );
 						element.setModel( new TranslationModel2D() );
 						element.setOffset( new float[]{ (float)locationX, (float)locationY } );
 						element.setDimensionality( 2 );


### PR DESCRIPTION
I've been working with lightsheet multiseries .czi files and tried to stitch with the "Positions from file" mode, but the resulting tiles all came from the same series. The fix for me was to set the series on value when building the ImporterOptions.

I also made a small simplification to use the series index directly when creating the ImageCollectionElement objects, though the change doesn't appear to be necessary.

I tested the changes in headless mode with a multiseries file generated by Zeiss Zen 2014 after dual illumination fusion, both with order "Defined by TileConfiguration" (including 3D and 2D subsets, with TileConfiguration.txt built separately beforehand) and "Defined by image metadata" (though my multiseries file does not appear to give tile offsets in the metadata). It'd be helpful to test with other multiseries files from other systems.