### PR TITLE
Add static utility class for scripting API

### DIFF
--- a/src/main/java/ch/fmi/visiview/StitchingUtils.java
+++ b/src/main/java/ch/fmi/visiview/StitchingUtils.java
@@ -1,0 +1,194 @@
+/*-
+ * #%L
+ * ImageJ plugins for processing VisiView datasets
+ * %%
+ * Copyright (C) 2019 Friedrich Miescher Institute for Biomedical
+ * 			Research, Basel
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package ch.fmi.visiview;
+
+import ij.ImagePlus;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import mpicbg.models.InvertibleBoundable;
+import mpicbg.models.TranslationModel2D;
+import mpicbg.models.TranslationModel3D;
+import mpicbg.stitching.CollectionStitchingImgLib;
+import mpicbg.stitching.ImageCollectionElement;
+import mpicbg.stitching.ImagePlusTimePoint;
+import mpicbg.stitching.StitchingParameters;
+import mpicbg.stitching.fusion.Fusion;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+
+/**
+ * 
+ * @author Jan Eglinger
+ *
+ */
+public class StitchingUtils {
+
+	private StitchingUtils() {
+		// prevent instantiation of static utility class
+	}
+
+	/**
+	 * Compute optimal tile positions from a list of known initial positions
+	 * 
+	 * @param images List of tiles
+	 * @param positions List of known positions
+	 * @param dimensionality 2 or 3
+	 * @param computeOverlap whether to compute the exact tile overlap, or to trust the known coordinates
+	 * @return List of transformation models
+	 */
+	public static ArrayList<InvertibleBoundable> computeStitching(ArrayList<ImagePlus> images, ArrayList<float[]> positions, int dimensionality, boolean computeOverlap) {
+		if (images.size() != positions.size()) {
+			throw new RuntimeException("number of images != number of positions");
+		}
+
+		// Create tile list
+		ArrayList<ImageCollectionElement> elements = new ArrayList<>();
+		float[] pos;
+		for (int i = 0; i < images.size(); i++) {
+			ImageCollectionElement element = new ImageCollectionElement(null, i);
+			element.setDimensionality( dimensionality );
+			element.setModel(dimensionality == 2 ? new TranslationModel2D() : new TranslationModel3D());
+			element.setImagePlus(images.get(i));
+			if (dimensionality == 2) {
+				element.setOffset(positions.get(i));
+			} else {
+				pos = positions.get(i);
+				element.setOffset(new float[] {pos[0], pos[1], 0});
+			}
+			elements.add(element);
+		}
+		
+		// Create parameters
+		StitchingParameters params = new StitchingParameters();
+		params.cpuMemChoice = 1; // faster, use more RAM
+		params.dimensionality = dimensionality;
+		params.computeOverlap = computeOverlap;
+		params.checkPeaks = 5;
+		params.subpixelAccuracy = true;
+
+		// Compute stitching
+		ArrayList<ImagePlusTimePoint> tiles = CollectionStitchingImgLib.stitchCollection(elements, params);
+
+		// Extract models
+		ArrayList<InvertibleBoundable> models = new ArrayList<>();
+		for (ImagePlusTimePoint tile : tiles) {
+			models.add((InvertibleBoundable) tile.getModel());
+		}
+		return models;
+	}
+
+	/**
+	 * Fuse a set of tiles, given a set of transformation models
+	 * 
+	 * @param images List of tiles
+	 * @param models List of transformation models
+	 * @param dimensionality 2 or 3
+	 * @return fused image
+	 */
+	public static ImagePlus fuseTiles(ArrayList<ImagePlus> images, ArrayList<InvertibleBoundable> models, int dimensionality) {
+		switch (images.get(0).getType()) {
+			case ImagePlus.GRAY8:
+				return Fusion.fuse(new UnsignedByteType(), images, models, dimensionality, true, 0, null, false, false, false);
+			case ImagePlus.GRAY16:
+				return Fusion.fuse(new UnsignedShortType(), images, models, dimensionality, true, 0, null, false, false, false);
+			case ImagePlus.GRAY32:
+				return Fusion.fuse(new FloatType(), images, models, dimensionality, true, 0, null, false, false, false);
+			default:
+				throw new RuntimeException("Unknown image type for fusion");
+		}
+	}
+
+	/**
+	 * Create a preview image of a tile layout
+	 * 
+	 * @param image {@code BufferedImage} to draw into
+	 * @param pixelPositions List of positions (2D pixel coordinates)
+	 * @param xSize Width of a single tile
+	 * @param ySize Height of a single tile
+	 */
+	public static void drawPositions(BufferedImage image, ArrayList<float[]> pixelPositions, long xSize, long ySize)
+	{
+		Float xMin = Float.POSITIVE_INFINITY;
+		Float yMin = Float.POSITIVE_INFINITY;
+		Float xMax = Float.NEGATIVE_INFINITY;
+		Float yMax = Float.NEGATIVE_INFINITY;
+
+		for (float[] p : pixelPositions) {
+			if (p[0] < xMin) xMin = p[0];
+			if (p[1] < yMin) yMin = p[1];
+			if (p[0] > xMax) xMax = p[0];
+			if (p[1] > yMax) yMax = p[1];
+		}
+
+		long tileWidth = xSize;
+		long tileHeight = ySize;
+
+		xMax += tileWidth;
+		yMax += tileHeight;
+
+		int width = image.getWidth();
+		int height = image.getHeight();
+		double scaledWidth = xMax - xMin;
+		double scaledHeight = yMax - yMin;
+		Float offsetX = xMin;
+		Float offsetY = yMin;
+		double factor = Math.max(scaledWidth, scaledHeight) / Math.min(width,
+			height);
+
+		Graphics g = image.getGraphics();
+		g.clearRect(0, 0, width, height);
+		int rgb = 0;
+		for (float[] p : pixelPositions) {
+			rgb = nextColor(rgb);
+			g.setXORMode(new Color(rgb)); // TODO replace by HSB color directly?
+			g.fillRect((int) ((p[0] - offsetX) / factor), (int) ((p[1] - offsetY) /
+				factor), (int) (tileWidth / factor), (int) (tileHeight / factor));
+		}
+		g.dispose();
+	}
+
+	private static int nextColor(int rgb) {
+		// Create a "golden angle" color sequence for best contrast, see:
+		// https://github.com/ijpb/MorphoLibJ/blob/c6c688f/src/main/java/inra/ijpb/util/ColorMaps.java#L315
+
+		float[] hsb = Color.RGBtoHSB((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb &
+			0xFF, null);
+		hsb[0] += 0.38197;
+		if (hsb[0] > 1) hsb[0] -= 1;
+		hsb[1] += 0.38197;
+		if (hsb[1] > 1) hsb[1] -= 1;
+		hsb[1] = 0.5f * hsb[1] + 0.5f;
+		return Color.HSBtoRGB(hsb[0], hsb[1], 1);
+	}
+}

--- a/src/main/java/ch/fmi/visiview/StitchingUtils.java
+++ b/src/main/java/ch/fmi/visiview/StitchingUtils.java
@@ -54,6 +54,13 @@ import net.imglib2.type.numeric.real.FloatType;
  */
 public class StitchingUtils {
 
+	public static final int BLENDING_FUSION = 0;
+	public static final int AVERAGE_FUSION = 1;
+	public static final int MEDIAN_FUSION = 2;
+	public static final int MAX_FUSION = 3;
+	public static final int MIN_FUSION = 4;
+	public static final int OVERLAP_FUSION = 5;
+
 	private StitchingUtils() {
 		// prevent instantiation of static utility class
 	}
@@ -109,6 +116,34 @@ public class StitchingUtils {
 	}
 
 	/**
+	 * Fuse a set of tiles, given a set of transformation models and a fusion type
+	 * 
+	 * @param images List of tiles
+	 * @param models List of transformation models
+	 * @param dimensionality 2 or 3
+	 * @param fusionType Type of fusion, one of the following:
+	 *   <li> {@code BLENDING_FUSION}
+	 *   <li> {@code AVERAGE_FUSION}
+	 *   <li> {@code MEDIAN_FUSION}
+	 *   <li> {@code MAX_FUSION}
+	 *   <li> {@code MIN_FUSION}
+	 *   <li> {@code OVERLAP_FUSION}
+	 * @return fused image
+	 */
+	public static ImagePlus fuseTiles(ArrayList<ImagePlus> images, ArrayList<InvertibleBoundable> models, int dimensionality, int fusionType) {
+		switch (images.get(0).getType()) {
+			case ImagePlus.GRAY8:
+				return Fusion.fuse(new UnsignedByteType(), images, models, dimensionality, true, fusionType, null, false, false, false);
+			case ImagePlus.GRAY16:
+				return Fusion.fuse(new UnsignedShortType(), images, models, dimensionality, true, fusionType, null, false, false, false);
+			case ImagePlus.GRAY32:
+				return Fusion.fuse(new FloatType(), images, models, dimensionality, true, fusionType, null, false, false, false);
+			default:
+				throw new RuntimeException("Unknown image type for fusion");
+		}
+	}
+
+	/**
 	 * Fuse a set of tiles, given a set of transformation models
 	 * 
 	 * @param images List of tiles
@@ -117,16 +152,7 @@ public class StitchingUtils {
 	 * @return fused image
 	 */
 	public static ImagePlus fuseTiles(ArrayList<ImagePlus> images, ArrayList<InvertibleBoundable> models, int dimensionality) {
-		switch (images.get(0).getType()) {
-			case ImagePlus.GRAY8:
-				return Fusion.fuse(new UnsignedByteType(), images, models, dimensionality, true, 0, null, false, false, false);
-			case ImagePlus.GRAY16:
-				return Fusion.fuse(new UnsignedShortType(), images, models, dimensionality, true, 0, null, false, false, false);
-			case ImagePlus.GRAY32:
-				return Fusion.fuse(new FloatType(), images, models, dimensionality, true, 0, null, false, false, false);
-			default:
-				throw new RuntimeException("Unknown image type for fusion");
-		}
+		return fuseTiles(images, models, dimensionality, BLENDING_FUSION);
 	}
 
 	/**

--- a/src/main/java/ch/fmi/visiview/StitchingUtils.java
+++ b/src/main/java/ch/fmi/visiview/StitchingUtils.java
@@ -122,12 +122,14 @@ public class StitchingUtils {
 	 * @param models List of transformation models
 	 * @param dimensionality 2 or 3
 	 * @param fusionType Type of fusion, one of the following:
-	 *   <li> {@code BLENDING_FUSION}
-	 *   <li> {@code AVERAGE_FUSION}
-	 *   <li> {@code MEDIAN_FUSION}
-	 *   <li> {@code MAX_FUSION}
-	 *   <li> {@code MIN_FUSION}
-	 *   <li> {@code OVERLAP_FUSION}
+	 * <ul>
+	 *   <li>{@code BLENDING_FUSION}</li>
+	 *   <li>{@code AVERAGE_FUSION}</li>
+	 *   <li>{@code MEDIAN_FUSION}</li>
+	 *   <li>{@code MAX_FUSION}</li>
+	 *   <li>{@code MIN_FUSION}</li>
+	 *   <li>{@code OVERLAP_FUSION}</li>
+	 * </ul>
 	 * @return fused image
 	 */
 	public static ImagePlus fuseTiles(ArrayList<ImagePlus> images, ArrayList<InvertibleBoundable> models, int dimensionality, int fusionType) {

--- a/src/main/java/mpicbg/stitching/StitchingUtils.java
+++ b/src/main/java/mpicbg/stitching/StitchingUtils.java
@@ -1,47 +1,33 @@
 /*-
  * #%L
- * ImageJ plugins for processing VisiView datasets
+ * Fiji distribution of ImageJ for the life sciences.
  * %%
- * Copyright (C) 2019 Friedrich Miescher Institute for Biomedical
- * 			Research, Basel
+ * Copyright (C) 2007 - 2020 Fiji developers.
  * %%
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
  * 
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
  * #L%
  */
 
-package ch.fmi.visiview;
+package mpicbg.stitching;
+
+import java.util.ArrayList;
 
 import ij.ImagePlus;
-import java.awt.Color;
-import java.awt.Graphics;
-import java.awt.image.BufferedImage;
-import java.util.ArrayList;
 import mpicbg.models.InvertibleBoundable;
 import mpicbg.models.TranslationModel2D;
 import mpicbg.models.TranslationModel3D;
-import mpicbg.stitching.CollectionStitchingImgLib;
-import mpicbg.stitching.ImageCollectionElement;
-import mpicbg.stitching.ImagePlusTimePoint;
-import mpicbg.stitching.StitchingParameters;
 import mpicbg.stitching.fusion.Fusion;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
@@ -155,68 +141,5 @@ public class StitchingUtils {
 	 */
 	public static ImagePlus fuseTiles(ArrayList<ImagePlus> images, ArrayList<InvertibleBoundable> models, int dimensionality) {
 		return fuseTiles(images, models, dimensionality, BLENDING_FUSION);
-	}
-
-	/**
-	 * Create a preview image of a tile layout
-	 * 
-	 * @param image {@code BufferedImage} to draw into
-	 * @param pixelPositions List of positions (2D pixel coordinates)
-	 * @param xSize Width of a single tile
-	 * @param ySize Height of a single tile
-	 */
-	public static void drawPositions(BufferedImage image, ArrayList<float[]> pixelPositions, long xSize, long ySize)
-	{
-		Float xMin = Float.POSITIVE_INFINITY;
-		Float yMin = Float.POSITIVE_INFINITY;
-		Float xMax = Float.NEGATIVE_INFINITY;
-		Float yMax = Float.NEGATIVE_INFINITY;
-
-		for (float[] p : pixelPositions) {
-			if (p[0] < xMin) xMin = p[0];
-			if (p[1] < yMin) yMin = p[1];
-			if (p[0] > xMax) xMax = p[0];
-			if (p[1] > yMax) yMax = p[1];
-		}
-
-		long tileWidth = xSize;
-		long tileHeight = ySize;
-
-		xMax += tileWidth;
-		yMax += tileHeight;
-
-		int width = image.getWidth();
-		int height = image.getHeight();
-		double scaledWidth = xMax - xMin;
-		double scaledHeight = yMax - yMin;
-		Float offsetX = xMin;
-		Float offsetY = yMin;
-		double factor = Math.max(scaledWidth, scaledHeight) / Math.min(width,
-			height);
-
-		Graphics g = image.getGraphics();
-		g.clearRect(0, 0, width, height);
-		int rgb = 0;
-		for (float[] p : pixelPositions) {
-			rgb = nextColor(rgb);
-			g.setXORMode(new Color(rgb)); // TODO replace by HSB color directly?
-			g.fillRect((int) ((p[0] - offsetX) / factor), (int) ((p[1] - offsetY) /
-				factor), (int) (tileWidth / factor), (int) (tileHeight / factor));
-		}
-		g.dispose();
-	}
-
-	private static int nextColor(int rgb) {
-		// Create a "golden angle" color sequence for best contrast, see:
-		// https://github.com/ijpb/MorphoLibJ/blob/c6c688f/src/main/java/inra/ijpb/util/ColorMaps.java#L315
-
-		float[] hsb = Color.RGBtoHSB((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb &
-			0xFF, null);
-		hsb[0] += 0.38197;
-		if (hsb[0] > 1) hsb[0] -= 1;
-		hsb[1] += 0.38197;
-		if (hsb[1] > 1) hsb[1] -= 1;
-		hsb[1] = 0.5f * hsb[1] + 0.5f;
-		return Color.HSBtoRGB(hsb[0], hsb[1], 1);
 	}
 }


### PR DESCRIPTION
I've been using this utility class `StitchingUtils` for a while now, e.g. when I need to stitch multi-series images that are not being read correctly via Bio-Formats, or for images that are loaded into memory already in scripting workflows, to avoid writing new files and relying on a `TileConfiguration.txt` file.

This adds the following static methods:
* `computeStitching(images, positions, dimensionality, computeOverlap)` returning the translation models for each tile,

as well as:

* `fuseTiles(images, models, dimensionality, fusionType)` and
* `fuseTiles(images, models, dimensionality)` performing the actual fusion (with blending being the default fusion method).

---

As there seems to be some community interest in having more accessible stitching API (e.g. in the discussion of https://github.com/imagej/pyimagej/issues/35), I thought it might make sense to migrate these utility methods upstream from [`faim-ij2-visiview-processing`](https://github.com/fmi-basel/faim-ij2-visiview-processing) into this repository.

@StephanPreibisch, @ctrueden let me know what you think.
